### PR TITLE
Fix formatting for consistency with rest of guides:

### DIFF
--- a/mvnbuild.adoc
+++ b/mvnbuild.adoc
@@ -13,9 +13,9 @@ To build the application, run the following command:
 
   mvn install
 
-This command builds the application and creates a .war file in the target directory. The command also configures and installs Liberty into the target/liberty/wlp directory. After the Maven build completes, you can use the server script in that Liberty installation. You can also start and stop the server by using the Maven goals of liberty:start-server and liberty:stop-server.
+This command builds the application and creates a `.war` file in the target directory. The command also configures and installs Liberty into the `target/liberty/wlp directory`. After the Maven build completes, you can use the server script in that Liberty installation. You can also start and stop the server by using the Maven goals of `liberty:start-server` and `liberty:stop-server`.
 
-If the server is running, then running the installation can cause issues because the installation attempts to start a server. You can instead run the following command:
+If the server is running, running the installation can cause issues because the installation attempts to start a server. You can instead run the following command:
 
     mvn package
 


### PR DESCRIPTION
* Add backticks (aka <code> tags) around file names and file paths so they're monospace and grey shading for consistency with rest of the guides.
* Remove unnecessary 'then' from 'if/then' statement in text.