### PR TITLE
Remove empty line from comment block to prevent unterminated comment block warning

### DIFF
--- a/gitclone.adoc
+++ b/gitclone.adoc
@@ -3,7 +3,6 @@
  Licensed under Creative Commons Attribution-NoDerivatives
  4.0 International (CC BY-ND 4.0)
    https://creativecommons.org/licenses/by-nd/4.0/
-
  Contributors:
      IBM Corporation
 ////

--- a/gitclonedraft.adoc
+++ b/gitclonedraft.adoc
@@ -3,7 +3,6 @@
  Licensed under Creative Commons Attribution-NoDerivatives
  4.0 International (CC BY-ND 4.0)
    https://creativecommons.org/licenses/by-nd/4.0/
-
  Contributors:
      IBM Corporation
 ////

--- a/kube-prereq.adoc
+++ b/kube-prereq.adoc
@@ -3,7 +3,6 @@
  Licensed under Creative Commons Attribution-NoDerivatives
  4.0 International (CC BY-ND 4.0)
    https://creativecommons.org/licenses/by-nd/4.0/
-
  Contributors:
      IBM Corporation
 ////

--- a/kube-start.adoc
+++ b/kube-start.adoc
@@ -3,7 +3,6 @@
  Licensed under Creative Commons Attribution-NoDerivatives
  4.0 International (CC BY-ND 4.0)
    https://creativecommons.org/licenses/by-nd/4.0/
-
  Contributors:
      IBM Corporation
 ////

--- a/mvnbuild.adoc
+++ b/mvnbuild.adoc
@@ -3,7 +3,6 @@
  Licensed under Creative Commons Attribution-NoDerivatives
  4.0 International (CC BY-ND 4.0)
    https://creativecommons.org/licenses/by-nd/4.0/
-
  Contributors:
      IBM Corporation
 ////

--- a/mvncompile.adoc
+++ b/mvncompile.adoc
@@ -3,7 +3,6 @@
  Licensed under Creative Commons Attribution-NoDerivatives
  4.0 International (CC BY-ND 4.0)
    https://creativecommons.org/licenses/by-nd/4.0/
-
  Contributors:
      IBM Corporation
 ////

--- a/mvnverify.adoc
+++ b/mvnverify.adoc
@@ -3,7 +3,6 @@
  Licensed under Creative Commons Attribution-NoDerivatives
  4.0 International (CC BY-ND 4.0)
    https://creativecommons.org/licenses/by-nd/4.0/
-
  Contributors:
      IBM Corporation
 ////


### PR DESCRIPTION
Jekyll is throwing up warnings.  This PR will fix them.
```
asciidoctor: WARNING: gitclone.adoc: line 2: unterminated comment block
asciidoctor: WARNING: gitclonedraft.adoc: line 2: unterminated comment block
asciidoctor: WARNING: kube-prereq.adoc: line 2: unterminated comment block
asciidoctor: WARNING: kube-start.adoc: line 2: unterminated comment block
asciidoctor: WARNING: mvnbuild.adoc: line 2: unterminated comment block
asciidoctor: WARNING: mvncompile.adoc: line 2: unterminated comment block
asciidoctor: WARNING: mvnverify.adoc: line 2: unterminated comment block
```