### PR TITLE
Allow customizable minikube start command

### DIFF
--- a/kube-start.adoc
+++ b/kube-start.adoc
@@ -19,8 +19,14 @@ Start your Docker Desktop environment.
 
 Run the following command from a command line:
 
+[subs="attributes"]
 ```
+ifdef::minikube-start[]
+{minikube-start}
+endif::[]
+ifndef::minikube-start[]
 minikube start
+endif::[]
 ```
 ****
 


### PR DESCRIPTION
Allow the guide writer to define a `minikube-start` variable to override the default `minikube start` command displayed in this partial document.