### PR TITLE
Updating hyperlinks in kube preq

### DIFF
--- a/kube-prereq.adoc
+++ b/kube-prereq.adoc
@@ -11,19 +11,19 @@
 Before you begin, make sure to have the following tools installed:
 
 First, you will need a containerization software for building containers. {kube} supports a variety
-of container types. You will use `Docker` in this guide. For installation instructions, see https://docs.docker.com/install/.
+of container types. You will use `Docker` in this guide. For installation instructions, see the https://docs.docker.com/install/[official Docker Page].
 
 ****
 [system]#*{win} | {mac}*#
 
-Use the Docker Desktop, where a local {kube} environment is pre-installed and enabled. If you do not see the {kube} tab then you have an older version of Docker Desktop; upgrade to the latest version.
+Use Docker Desktop, where a local {kube} environment is pre-installed and enabled. If you do not see the {kube} tab then you have an older version of Docker Desktop; upgrade to the latest version.
 
-- Set up Docker for Windows as described at https://docs.docker.com/docker-for-windows/#kubernetes.
-- Set up Docker for Mac as described at https://docs.docker.com/docker-for-mac/#kubernetes.
+- Set up Docker for Windows as described at https://docs.docker.com/docker-for-windows/#kubernetes[Docker for Windows].
+- Set up Docker for Mac as described at https://docs.docker.com/docker-for-mac/#kubernetes[Docker for Mac].
 - After following one of the sets of instructions, ensure that {kube} (not Swarm) is selected as the orchestrator in Docker Preferences.
 
 [system]#*{linux}*#
 
 You will use `Minikube` as a single-node {kube} cluster that runs locally in a virtual machine.
-For Minikube installation instructions see https://github.com/kubernetes/minikube. Make sure to read the "Requirements" section as different operating systems require different prerequisites to get Minikube running.
+For Minikube installation instructions see the https://github.com/kubernetes/minikube[minikube installation instructions]. Make sure to read the "Requirements" section as different operating systems require different prerequisites to get Minikube running.
 ****

--- a/kube-prereq.adoc
+++ b/kube-prereq.adoc
@@ -25,5 +25,5 @@ Use Docker Desktop, where a local {kube} environment is pre-installed and enable
 [system]#*{linux}*#
 
 You will use `Minikube` as a single-node {kube} cluster that runs locally in a virtual machine.
-For Minikube installation instructions see the https://github.com/kubernetes/minikube[minikube installation instructions]. Make sure to read the "Requirements" section as different operating systems require different prerequisites to get Minikube running.
+For Minikube installation instructions see the https://github.com/kubernetes/minikube#installation[minikube installation instructions]. Make sure to read the https://github.com/kubernetes/minikube#requirements[Requirements] section as different operating systems require different prerequisites to get Minikube running.
 ****


### PR DESCRIPTION
- Updated the hyperlinks 
- Removed "the" in this sentence: "Use the Docker Desktop..."