### PR TITLE
Add 'by Open Liberty' to the attribution

### DIFF
--- a/attribution.adoc
+++ b/attribution.adoc
@@ -10,4 +10,4 @@
 == Guide Attribution
 
 // Specify where the guide is attributed to.
-{doctitle} [licensedClass]#is licensed under# CC BY-ND 4.0 
+{doctitle} [licensedClass]#by# Open Liberty [licensedClass]#is licensed under# CC BY-ND 4.0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6392944/50600444-b3623b80-0e76-11e9-8a96-ba564291f5ac.png)


I tried to add an optional guide-author attribute to replace Open Liberty for other authors but asciidoc didn't pick up the ifdef syntax from the included adoc.
{doctitle} [licensedClass]#by# ifdef:guide-author[] {guide-author} endif:guide-author[] ifndef:guide-author[] Open Liberty endif:guide-author[] [licensedClass]#is licensed under# CC BY-ND 4.0

For now this will address all of the guides by Open Liberty.