### PR TITLE
Add the attribution file to the master branch

### DIFF
--- a/attribution.adoc
+++ b/attribution.adoc
@@ -1,0 +1,13 @@
+////
+ Copyright (c) 2018 IBM Corporation and others.
+ Licensed under Creative Commons Attribution-NoDerivatives
+ 4.0 International (CC BY-ND 4.0)
+   https://creativecommons.org/licenses/by-nd/4.0/
+
+ Contributors:
+     IBM Corporation
+////
+== Guide Attribution
+
+// Specify where the guide is attributed to.
+{doctitle} [licensedClass]#by# {guide-author} [licensedClass]#is licensed under# CC BY-ND 4.0


### PR DESCRIPTION
We need to move this file into master so that the guide asciidoc's can change this line:
```include::https://raw.githubusercontent.com/OpenLiberty/guides-common/multipane/attribution.adoc[subs="attributes"]```
to:
```include::{common-includes}/attribution.adoc[subs="attributes"]```
so that when the multipane branch is merged into master it is not referring to multipane.
Note the path before has multipane in it.