### PR TITLE
Add tags to twyb-intro.adoc

### DIFF
--- a/twyb-intro.adoc
+++ b/twyb-intro.adoc
@@ -2,6 +2,7 @@
 
 The `finish` directory in the root of this guide contains the finished application. Give it a try before you proceed.
 
+// tag::runCommand[]
 To try out the application, first go to the `finish` directory and run the following
 Maven goal to build the application and deploy it to Open Liberty:
 
@@ -16,3 +17,4 @@ After you see the following message, your application server is ready.
 ----
 The defaultServer server is ready to run a smarter planet.
 ----
+// end::runCommand[]


### PR DESCRIPTION
`The finish directory in the root of this guide contains the finished application.` is usually a common sentence in most of the guides, so it should be kept in the adoc. 

However, there might be times you want to just modify this sentence slightly, e.g. 
`The finish directory in the root of this guide contains the finished application secured with form authentication`.

But if you want to keep the rest of the adoc, instead of copying the text you want from the adoc,
just include the rest of the adoc using tags:
```
[role='command']
include::{common-includes}/twyb-intro.adoc[tag=runCommand]
```