### PR TITLE
Merge qa to master: add microprofile-opentracing-jaeger to categories and tags

### DIFF
--- a/guide_categories.json
+++ b/guide_categories.json
@@ -26,7 +26,7 @@
             },
             {
                 "subcategory_name": "Observability",
-                "guides": ["microprofile-metrics", "microprofile-opentracing", "microprofile-health", "kubernetes-microprofile-health"]
+                "guides": ["microprofile-metrics", "microprofile-opentracing", "microprofile-opentracing-jaeger", "microprofile-health", "kubernetes-microprofile-health"]
             },
             {
                 "subcategory_name": "Security",

--- a/guide_tags.json
+++ b/guide_tags.json
@@ -17,7 +17,7 @@
             "additional_search_terms": ["Micro Profile", "MP"],
             "guides": ["cdi-intro", "kubernetes-microprofile-config", "kubernetes-microprofile-health", "microprofile-config", 
                 "microprofile-fallback", "microprofile-health", "microprofile-istio-retry-fallback", "microprofile-jwt", 
-                "microprofile-metrics", "microprofile-openapi", "microprofile-opentracing", "microprofile-rest-client", 
+                "microprofile-metrics", "microprofile-openapi", "microprofile-opentracing", "microprofile-opentracing-jaeger", "microprofile-rest-client", 
                 "microprofile-rest-client-async", "microshed-testing", "rest-client-java", "rest-intro", "bulkhead", 
                 "circuit-breaker", "microprofile-config-intro", "retry-timeout", "microprofile-reactive-messaging", "reactive-service-testing", "microprofile-reactive-messaging-rest-integration"],
             "visible": "true"

--- a/guide_tags.json
+++ b/guide_tags.json
@@ -67,11 +67,11 @@
         },
         {
             "name": "OpenTracing",
-            "guides": ["microprofile-opentracing"]
+            "guides": ["microprofile-opentracing", "microprofile-opentracing-jaeger"]
         },
         {
             "name": "@Traced",
-            "guides": ["microprofile-opentracing"]
+            "guides": ["microprofile-opentracing", "microprofile-opentracing-jaeger"]
         },
         {
             "name": "Testing",


### PR DESCRIPTION
publish the new microprofile-opentracing-jaeger guide