### PR TITLE
Update twyb-intro.adoc

### DIFF
--- a/twyb-intro.adoc
+++ b/twyb-intro.adoc
@@ -12,7 +12,7 @@ cd finish
 mvn liberty:run
 ```
 
-After you see the following message, your application server is ready.
+After you see the following message, your application server is ready:
 
 [role="no_copy"]
 ----


### PR DESCRIPTION
Add a colon after "After you see the following message, your application server is ready" instead of a period. See https://github.com/OpenLiberty/draft-guide-mongodb/issues/55