### PR TITLE
Update ol-kernel-docker-pull.adoc

### DIFF
--- a/ol-kernel-docker-pull.adoc
+++ b/ol-kernel-docker-pull.adoc
@@ -1,4 +1,4 @@
-Run the following command to download or update to the latest `openliberty/open-liberty:kernel-java8-openj9-ubi` Docker image:
+Run the following command to download or update to the latest Open Liberty Docker image:
 
 [role='command']
 ```


### PR DESCRIPTION
Changed `openliberty/open-liberty:kernel-java8-openj9-ubi` to simply `Open Liberty`.