### PR TITLE
Merge qa to master: new start dev mode adoc for LMP 3.3

### DIFF
--- a/devmode-lmp33-start-cd.adoc
+++ b/devmode-lmp33-start-cd.adoc
@@ -1,0 +1,19 @@
+When you run Open Liberty in development mode, known as dev mode, the server listens for file changes and automatically recompiles and 
+deploys your updates whenever you save a new change. Run the following goal to start Open Liberty in dev mode:
+
+[role=command]
+```
+cd start
+mvn liberty:dev
+```
+
+After you see the following message, your application server in dev mode is ready:
+
+[role="no_copy"]
+----
+************************************************************************
+*    Liberty is running in dev mode.
+----
+
+Dev mode holds your command-line session to listen for file changes. Open another command-line session to continue, 
+or open the project in your editor.

--- a/devmode-lmp33-start.adoc
+++ b/devmode-lmp33-start.adoc
@@ -1,0 +1,18 @@
+When you run Open Liberty in development mode, known as dev mode, the server listens for file changes and automatically recompiles and 
+deploys your updates whenever you save a new change. Run the following goal to start Open Liberty in dev mode:
+
+[role=command]
+```
+mvn liberty:dev
+```
+
+After you see the following message, your application server in dev mode is ready:
+
+[role="no_copy"]
+----
+************************************************************************
+*    Liberty is running in dev mode.
+----
+
+Dev mode holds your command-line session to listen for file changes. Open another command-line session to continue, 
+or open the project in your editor.


### PR DESCRIPTION
The ready message was changed to
```
[INFO] ************************************************************************
[INFO] *    Liberty is running in dev mode.
[INFO] *        To run tests on demand, press Enter.
[INFO] *        To restart the server, type 'r' and press Enter.
[INFO] *        To stop the server and quit dev mode, press Ctrl-C or type 'q' and press Enter.
[INFO] *        
[INFO] *    Liberty server port information:
[INFO] *        Liberty server HTTP port: [ 9080 ]
[INFO] *        Liberty server HTTPS port: [ 9443 ]
[INFO] *        Liberty debug port: [ 7777 ]
[INFO] ************************************************************************
```