### PR TITLE
Merge qa to master: remove guide-cloud-openshift-operator from daily docker build test

### DIFF
--- a/.github/workflows/docker-guides.json
+++ b/.github/workflows/docker-guides.json
@@ -3,7 +3,6 @@
     "guide-cloud-aws",
     "guide-cloud-ibm",
     "guide-cloud-openshift",
-    "guide-cloud-openshift-operator",
     "guide-docker",
     "guide-getting-started",
     "guide-istio-intro",


### PR DESCRIPTION
https://github.com/OpenLiberty/guides-common/commit/437df717601084b78361c4d685616598ca069aba