### PR TITLE
Merge qa to master: Update docker-daily-test.yml to use default instead of gh-actions (#581)

### DIFF
--- a/.github/workflows/docker-daily-test.yml
+++ b/.github/workflows/docker-daily-test.yml
@@ -65,7 +65,6 @@ jobs:
         with:
           repository: OpenLiberty/${{ matrix.repos }}
           path: ${{ matrix.repos }}
-          ref: refs/heads/gh-actions
       - name: Set permissions
         run: chmod +x ${{ matrix.repos }}/scripts/*.sh
       - name: Docker login


### PR DESCRIPTION
* Update docker-daily-test.yml

* Update docker-daily-test.yml