### PR TITLE
Enabling :page-tags: validation

### DIFF
--- a/pr-checker/checker.sh
+++ b/pr-checker/checker.sh
@@ -14,4 +14,4 @@ else
     echo "::set-output name=canSkip::false"
 fi
 
-python3 tools/pr-checker/checker.py --deny tools/pr-checker/deny_list.json --warn tools/pr-checker/warning_list.json $(echo $FILES | jq '.[]' | tr -d '"')
+python3 tools/pr-checker/checker.py --deny tools/pr-checker/deny_list.json --warn tools/pr-checker/warning_list.json --tags tools/guide_tags.json $(echo $FILES | jq '.[]' | tr -d '"')


### PR DESCRIPTION
Validating page-tags in the `README.adoc` against `guide_tags.json` in the guides-common repo