### PR TITLE
Changing some PR checker severity from error to warning

### DIFF
--- a/pr-checker/linters/sun_checks.xml
+++ b/pr-checker/linters/sun_checks.xml
@@ -155,6 +155,8 @@
     <module name="IllegalInstantiation" />
     <module name="InnerAssignment" />
     <module name="MagicNumber" />
+      <property name="severity" value="warning"/>
+    </module>
     <module name="MissingSwitchDefault" />
     <module name="MultipleVariableDeclarations" />
     <module name="SimplifyBooleanExpression" />
@@ -167,6 +169,8 @@
     <!-- See https://checkstyle.org/config_misc.html -->
     <module name="ArrayTypeStyle" />
     <module name="FinalParameters" />
+      <property name="severity" value="warning"/>
+    </module >
     <module name="TodoComment" />
     <module name="UpperEll" />
 


### PR DESCRIPTION
Changing `magic number` and `final parameter` java checks from `error` to `warning`