### PR TITLE
Update PR checker

### DIFF
--- a/pr-checker/checker.py
+++ b/pr-checker/checker.py
@@ -83,7 +83,7 @@ def adoc_checker(file, valid_tags, rules):
         output += f"[{rules['release_date']['log-level']}] Add a release date.\n"
     if rules['line-length']['lines']:
         output += f"[{rules['line-length']['log-level']}] The following lines are longer than 120 characters:\n"
-        output += f"[{rules['line-length']['log-level']}] {rules['lines']}\n"
+        output += f"[{rules['line-length']['log-level']}] {rules['line-length']['lines']}\n"
         output += f"[{rules['line-length']['log-level']}] Consider wrapping text to improve readability.\n"
     return output
 
@@ -158,7 +158,7 @@ if __name__ == "__main__":
             tags = []
     if args.rules is not None and args.repo is not None:
         try:
-            repo = args.repo.split('/')[-1]
+            repo = args.repo[0].split('/')[-1]
             rules = dict(map(lambda rule: (rule[0], {'check': repo not in rule[1]['exception'], 'log-level': rule[1]['log-level']}),
                              json.loads(args.rules[0].read()).items()))
         except:

--- a/pr-checker/checker.sh
+++ b/pr-checker/checker.sh
@@ -12,7 +12,7 @@ URL="https://api.github.com/repos/$repo/pulls/$pr_number/files"
 UPDATED_FILES="$(curl -s -X GET -G $URL | jq -r '[ .[] | select(.status != "removed") | .filename ]' | tr -d '\n')"
 ALL_FILES="$(curl -s -X GET -G $URL | jq -r '[ .[] |  .filename ]' | tr -d '\n')"
 
-echo $UPDATED_FILES
+echo "$UPDATED_FILES"
 if [ $(echo $ALL_FILES | jq 'length') = 1 ] && [ $(echo $ALL_FILES | jq '.[0]' | tr -d '"') = "README.adoc" ]; then
     echo "Test can be skipped because only README.adoc was updated"
     echo "::set-output name=canSkip::true"
@@ -21,4 +21,4 @@ else
     echo "::set-output name=canSkip::false"
 fi
 
-python3 "$SCRIPTPATH"/checker.py --deny "$SCRIPTPATH"/deny_list.json --warn "$SCRIPTPATH"/warning_list.json --tags "$SCRIPTPATH"/../guide_tags.json $(echo $UPDATED_FILES | jq '.[]' | tr -d '"')
+python3 "$SCRIPTPATH"/checker.py --deny "$SCRIPTPATH"/deny_list.json --warn "$SCRIPTPATH"/warning_list.json --tags "$SCRIPTPATH"/../guide_tags.json --repo "$repo" --rules "$SCRIPTPATH"/rules.json $(echo $UPDATED_FILES | jq '.[]' | tr -d '"')

--- a/pr-checker/rules.json
+++ b/pr-checker/rules.json
@@ -1,0 +1,25 @@
+{
+    "-": {
+        "log-level": "ERROR",
+        "exception": [
+            "guide-microprofile-openapi"
+        ],
+        "regex": "TO-DO add functionality to add new rules directly into this file"
+    },
+    "license": {
+        "log-level": "ERROR",
+        "exception": []
+    },
+    "release_date": {
+        "log-level": "ERROR",
+        "exception": []
+    },
+    "page_tags": {
+        "log-level": "ERROR",
+        "exception": []
+    },
+    "line-length": {
+        "log-level": "WARNING",
+        "exception": []
+    }
+}


### PR DESCRIPTION
Added a `rules.json` file to:
  - add exceptions to particular rules that the PR checker verifies.
     ie. When adding a guide name under exception, the checker will not verify if that guide satisfies that rule.
  - change log-level of a rule 

Added `guide-microprofile-openapi` to exceptions for the `- ` rule.