### PR TITLE
Add id to the git clone code block

### DIFF
--- a/gitclone.adoc
+++ b/gitclone.adoc
@@ -10,7 +10,7 @@
 
 The fastest way to work through this guide is to clone the https://github.com/openliberty/guide-{projectid}.git[Git repository^] and use the projects that are provided inside:
 
-[source, role="command", subs="attributes"]
+[source#git_clone, role="command", subs="attributes"]
 ----
 git clone https://github.com/openliberty/guide-{projectid}.git
 cd guide-{projectid}


### PR DESCRIPTION
Add id to the git clone block, so we can track copy to clipboard.