### PR TITLE
Updating Java Linter rules

### DIFF
--- a/pr-checker/linters/sun_checks.xml
+++ b/pr-checker/linters/sun_checks.xml
@@ -111,9 +111,7 @@
     <module name="IllegalImport" />
     <!-- defaults to sun.* packages -->
     <module name="RedundantImport" />
-    <module name="UnusedImports">
-      <property name="processJavadoc" value="false" />
-    </module>
+
 
     <!-- Checks for Size Violations.                    -->
     <!-- See https://checkstyle.org/config_sizes.html -->


### PR DESCRIPTION
Removing "unused imports" check from java linter