### PR TITLE
Cloud hosted Kubernetes instruction

### DIFF
--- a/skills-network-kube-setup.adoc
+++ b/skills-network-kube-setup.adoc
@@ -1,0 +1,43 @@
+ifdef::cloud-hosted[]
+
+== Logging into your cluster
+
+For this guide, you will use a container registry on IBM Cloud to deploy to Kubernetes.
+Get the name of your namespace with the following command:
+
+```
+bx cr namespace-list
+```
+{: codeblock}
+
+Look for output that is similar to the following:
+
+```
+Listing namespaces for account 'QuickLabs - IBM Skills Network' in registry 'us.icr.io'...
+
+Namespace
+sn-labs-yourname
+```
+
+Store the namespace name in a variable.
+Use the namespace name that was obtained from the previous command.
+
+```
+NAMESPACE_NAME={namespace_name}
+```
+{: codeblock}
+
+Verify that the variable contains your namespace name:
+
+```
+echo $NAMESPACE_NAME
+```
+{: codeblock}
+
+Log in to the registry with the following command:
+```
+bx cr login
+```
+{: codeblock}
+
+endif::[]

--- a/skills-network-kube-setup.adoc
+++ b/skills-network-kube-setup.adoc
@@ -1,3 +1,12 @@
+////
+ Copyright (c) 2021 IBM Corporation and others.
+ Licensed under Creative Commons Attribution-NoDerivatives
+ 4.0 International (CC BY-ND 4.0)
+   https://creativecommons.org/licenses/by-nd/4.0/
+ Contributors:
+     IBM Corporation
+////
+
 ifdef::cloud-hosted[]
 
 == Logging into your cluster


### PR DESCRIPTION
Common instructions for setting up Kubernetes on the cloud hosted versions of the guides on Skills Network