### PR TITLE
Update deny_list.json

### DIFF
--- a/pr-checker/deny_list.json
+++ b/pr-checker/deny_list.json
@@ -2,5 +2,6 @@
     "blacklist",
     "whitelist",
     "slave",
-    "OpenLiberty"
+    "OpenLiberty ",
+    " OpenLiberty"
 ]


### PR DESCRIPTION
Replaces "OpenLiberty" in `deny_list.json` with " OpenLiberty" and "Openliberty " to ensure URLs are not flagged as errors.