### PR TITLE
Update cloud-hosted-guides.json (#698)

### DIFF
--- a/cloud-hosted-guides.json
+++ b/cloud-hosted-guides.json
@@ -7,6 +7,9 @@
    "stagingSkillNetworkUrl": "https://ol-staging.skillsnetwork.site/quicklab/cloud-hosted-guide-{projectid}-staging",
    "guides": [
        "rest-client-java", "getting-started", "microprofile-openapi", "rest-intro", "microprofile-rest-client-async",
-       "containerize", "microprofile-rest-client", "kubernetes-intro", "microprofile-health", "microprofile-jwt"
+       "containerize", "microprofile-rest-client", "kubernetes-intro", "microprofile-health", "microprofile-jwt",
+       "cdi-intro", "microshed-testing", "docker",
+       "microprofile-config", "microprofile-fallback", "microprofile-metrics", "microprofile-opentracing", "microprofile-opentracing-jaeger",
+       "microprofile-reactive-messaging", "reactive-service-testing", "microprofile-reactive-messaging-acknowledgment", "microprofile-reactive-messaging-rest-integration" 
    ] 
 }


### PR DESCRIPTION
enable 22 cloud-hosted guides