### PR TITLE
Update guide_tags.json

### DIFF
--- a/guide_tags.json
+++ b/guide_tags.json
@@ -136,6 +136,16 @@
         {
             "name": "@Timeout",
             "guides": ["retry-timeout"]
+        },
+        {
+            "name": "Run in cloud",
+            "guides": [ 
+                "rest-client-java", "getting-started", "microprofile-openapi", "rest-intro", "microprofile-rest-client-async",
+                "containerize", "microprofile-rest-client", "kubernetes-intro", "microprofile-health", "microprofile-jwt",
+                "cdi-intro", "microshed-testing", "docker",
+                "microprofile-config", "microprofile-fallback", "microprofile-metrics", "microprofile-opentracing", "microprofile-opentracing-jaeger",
+                "microprofile-reactive-messaging", "reactive-service-testing", "microprofile-reactive-messaging-acknowledgment", "microprofile-reactive-messaging-rest-integration" 
+            ]
         }
     ]
 }


### PR DESCRIPTION
Add an invisible tag for searching the cloud-hosted guides
issue: #705 