### PR TITLE
remove RunInCloud tag

### DIFF
--- a/guide_tags.json
+++ b/guide_tags.json
@@ -138,7 +138,6 @@
         },
         {
             "name": "Run in cloud",
-            "additional_search_terms": ["RunInCloud"],
             "guides": [ 
                 "rest-client-java", "getting-started", "microprofile-openapi", "rest-intro", "microprofile-rest-client-async",
                 "containerize", "microprofile-rest-client", "kubernetes-intro", "microprofile-health", "microprofile-jwt",


### PR DESCRIPTION
RunInCloud seems like an unnecessary tag.  We have other tags with spaces, and the url can just use %20 for the whitespaces, for example: https://guides-draft-openlibertyio.mybluemix.net/guides/?search=run%20in%20cloud