### PR TITLE
Update guide_prereqs.json

### DIFF
--- a/guide_prereqs.json
+++ b/guide_prereqs.json
@@ -1,8 +1,8 @@
 {
     "prereqs": [
         {
-            "name": "Java",
-            "link": "https://adoptopenjdk.net/?jvmVariant=openj9",
+            "name": "Java SDK",
+            "link": "https://developer.ibm.com/languages/java/semeru-runtimes/downloads",
             "guides": ["*"]
         },
         {


### PR DESCRIPTION
rename the Java prereq to Java SDK and update the link to IBM Semeru Runtimes download page to address issue #686 and #703