### PR TITLE
Merge staging to prod - enable 2 cloud hosted guides

### DIFF
--- a/cloud-hosted-guides.json
+++ b/cloud-hosted-guides.json
@@ -53,6 +53,8 @@
      "rest-client-angularjs"           : "/courses/course-v1:IBM+GPXX0RL8EN+v1/auto_enroll?next=/courses/course-v1:IBM+GPXX0RL8EN+v1/courseware/guided_project/guided_project",
      "rest-client-reactjs"             : "/courses/course-v1:IBM+GPXX0G81EN+v1/auto_enroll?next=/courses/course-v1:IBM+GPXX0G81EN+v1/courseware/guided_project/guided_project",
      "rest-hateoas"                    : "/courses/course-v1:IBM+GPXX0MP0EN+v1/auto_enroll?next=/courses/course-v1:IBM+GPXX0MP0EN+v1/courseware/guided_project/guided_project",
-     "maven-multimodules"              : "/courses/course-v1:IBM+GPXX0J71EN+v1/auto_enroll?next=/courses/course-v1:IBM+GPXX0J71EN+v1/courseware/guided_project/guided_project"
+     "maven-multimodules"              : "/courses/course-v1:IBM+GPXX0J71EN+v1/auto_enroll?next=/courses/course-v1:IBM+GPXX0J71EN+v1/courseware/guided_project/guided_project",
+     "openliberty-operator-intro"      : "/courses/course-v1:IBM+GPXX0HAAEN+v1/auto_enroll?next=/courses/course-v1:IBM+GPXX0HAAEN+v1/courseware/guided_project/guided_project",
+     "openliberty-operator-openshift"  : "/courses/course-v1:IBM+GPXX0M5NEN+v1/auto_enroll?next=/courses/course-v1:IBM+GPXX0M5NEN+v1/courseware/guided_project/guided_project"
    }
 }

--- a/guide_tags.json
+++ b/guide_tags.json
@@ -147,7 +147,8 @@
                 "microprofile-reactive-messaging", "reactive-service-testing", "microprofile-reactive-messaging-acknowledgment", "microprofile-reactive-messaging-rest-integration",
                 "contract-testing", "kubernetes-microprofile-health", "kubernetes-microprofile-config", "reactive-messaging-sse", "reactive-rest-client",
                 "spring-boot", "arquillian-managed", "bean-validation", "cors", "jpa-intro",
-                "microprofile-graphql", "maven-intro", "rest-client-angular", "rest-client-angularjs", "rest-client-reactjs", "rest-hateoas", "maven-multimodules"
+                "microprofile-graphql", "maven-intro", "rest-client-angular", "rest-client-angularjs", "rest-client-reactjs", "rest-hateoas", "maven-multimodules",
+                "openliberty-operator-openshift", "openliberty-operator-openshift"
             ],
             "visible": "true"
         }


### PR DESCRIPTION
enable the cloud hosted version of the openliberty-operator-intro and openliberty-operato-openshift guides
