### PR TITLE
Update guide-redirects.properties

### DIFF
--- a/guide-redirects.properties
+++ b/guide-redirects.properties
@@ -15,3 +15,4 @@
 ################################################################################################
 
 /guides/microprofile-intro.html=/guides/cdi-intro.html
+/guides/cloud-openshift.html=/guides/cloud-openshift-operator.html


### PR DESCRIPTION
to deprecate the cloud-openshift guide, redirect the url `/guides/cloud-openshift.html` to `/guides/cloud-openshift-operator.html`