### PR TITLE
Update copyright headers

### DIFF
--- a/pr-checker/linters/config/java.header
+++ b/pr-checker/linters/config/java.header
@@ -2,11 +2,10 @@
 ^/\*{79}$
 ^ \* Copyright \(c\) (\d\d\d\d, )?\d\d\d\d IBM Corporation and others.$
 ^ \* All rights reserved. This program and the accompanying materials$
-^ \* are made available under the terms of the Eclipse Public License v1.0$
+^ \* are made available under the terms of the Eclipse Public License 2.0$
 ^ \* which accompanies this distribution, and is available at$
-^ \* http://www.eclipse.org/legal/epl-v10.html$
+^ \* http://www.eclipse.org/legal/epl-2.0/$
 ^ \*$
-^ \* Contributors:$
-^ \*     IBM Corporation - Initial implementation$
+^ \* SPDX-License-Identifier: EPL-2.0$
 ^ \*{79}/$
 ^// end::copyright\[\]$


### PR DESCRIPTION
update Liberty Copyright Headers according to https://github.ibm.com/websphere/WS-CD-Open/wiki/Liberty-Copyright-Headers