### PR TITLE
Update guide-redirects.properties and guide_tags.json

### DIFF
--- a/guide-redirects.properties
+++ b/guide-redirects.properties
@@ -14,5 +14,5 @@
 # (for that to happen, /a/=/b/ will also need to be included in the redirect list.
 ################################################################################################
 
-# /guides/microprofile-intro.html=/guides/cdi-intro.html
-# /guides/cloud-openshift.html=/guides/cloud-openshift-operator.html
+/guides/microprofile-intro.html=/guides/cdi-intro.html
+/guides/cloud-openshift.html=/guides/cloud-openshift-operator.html

--- a/guide_tags.json
+++ b/guide_tags.json
@@ -156,11 +156,10 @@
         {
             "name": "deprecated",
             "guides": [
-                "microprofile-opentracing", "microprofile-rest-client", "microprofile-metrics"
+                "microprofile-opentracing", "microprofile-opentracing-jaeger", "microshed-testing"
             ],
             "alt_links":{
-                "microprofile-opentracing" : "microprofile-opentracing-jaeger",
-                "microprofile-rest-client" : "microprofile-rest-client-async"
+                "microprofile-opentracing" : "microprofile-opentracing-jaeger"
             }
         }
     ]

--- a/guide_tags.json
+++ b/guide_tags.json
@@ -156,7 +156,7 @@
         {
             "name": "deprecated",
             "guides": [
-                "microprofile-opentracing", "microprofile-opentracing-jaeger", "microshed-testing"
+                "microprofile-opentracing", "microshed-testing"
             ],
             "alt_links":{
                 "microprofile-opentracing" : "microprofile-opentracing-jaeger"


### PR DESCRIPTION
restore the guide-redirects.properties because we still need the redirections.
update guide_tags.json for the guides that will really be deprecated