### PR TITLE
enable deepdive-gradle guide to run on daily build java 17

### DIFF
--- a/.github/workflows/daily-build-java17.yml
+++ b/.github/workflows/daily-build-java17.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get default repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
-        run: echo "repos=[ 'guide-spring-boot', 'guide-liberty-deep-dive', 'guide-contract-testing' ]" >> $GITHUB_OUTPUT
+        run: echo "repos=[ 'guide-spring-boot', 'guide-liberty-deep-dive', 'guide-liberty-deep-dive-gradle', 'guide-contract-testing' ]" >> $GITHUB_OUTPUT
       - name: Set input repo
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.guide != 'all' }}
         id: input-guide


### PR DESCRIPTION
deepdive-gradle guide requires java 17