### PR TITLE
Merge staging to prod - Enable spring boot guide to run java21 daily builds (#1101)

### DIFF
--- a/.github/workflows/daily-build-java21.yml
+++ b/.github/workflows/daily-build-java21.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Get default repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
-        run: echo "repos=[ 'guide-jpa-intro' ]" >> $GITHUB_OUTPUT
+        run: echo "::set-output name=repos::$(python3 .github/workflows/get-guides-java21.py)"
       - name: Set input repo
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.guide != 'all' }}
         id: input-guide
-        run: echo "repo=[ '${{ github.event.inputs.guide }}' ]" >> $GITHUB_OUTPUT
+        run: echo "::set-output name=repo::[ '${{ github.event.inputs.guide }}' ]"
   build-level:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-daily-test-java17.yml
+++ b/.github/workflows/docker-daily-test-java17.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
-        run: echo "repos=[ 'guide-spring-boot', 'guide-liberty-deep-dive' ]" >> $GITHUB_OUTPUT
+        run: echo "repos=[ 'guide-liberty-deep-dive' ]" >> $GITHUB_OUTPUT
       - name: Set repo
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.guide != 'all' }}
         id: input-guide

--- a/.github/workflows/docker-daily-test-java21.yml
+++ b/.github/workflows/docker-daily-test-java21.yml
@@ -1,16 +1,18 @@
-name: Manual GM candidate container test - Java 17
+name: Test Docker Daily Build - Java 21
 
 on:
+  repository_dispatch:
+    types: [ docker-image-test-java21 ]
   workflow_dispatch:
     inputs:
       build:
-        description: Build level as cl241020240923-1638
+        description: Build level as cl231220231122-1901
         required: true
       date:
-        description: Dev date as 2024-09-23_1638
+        description: Dev date as 2023-11-22_1901
         required: true
-      ol_version:
-        description: OL version as 24.0.0.10
+      driver:
+        description: Driver location as openliberty-all-23.0.0.12-cl231220231122-1901.zip
         required: true
       guide:
         description: Guide to build
@@ -26,7 +28,7 @@ env:
   CHANGE_MINIKUBE_NONE_USER: true
 
 jobs:
-  get-guide-repos:
+  get-repos:
     runs-on: ubuntu-latest
     outputs:
       repos: ${{ steps.create-list.outputs.repos }}${{ steps.input-guide.outputs.repo }}
@@ -35,7 +37,7 @@ jobs:
       - name: Get repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
-        run: echo "repos=[ 'guide-liberty-deep-dive' ]" >> $GITHUB_OUTPUT
+        run: echo "repos=[ 'guide-spring-boot' ]" >> $GITHUB_OUTPUT
       - name: Set repo
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.guide != 'all' }}
         id: input-guide
@@ -43,24 +45,24 @@ jobs:
   build-level:
     runs-on: ubuntu-latest
     steps:
-      - name: Starting GM candidate container tests for ${{ github.event.inputs.build }}
+      - name: Starting daily build tests for ${{ github.event.client_payload.build-level }}${{ github.event.inputs.build }}
         run: |
           echo "Inputs: "
-          echo   build:      ${{ github.event.inputs.build }}
-          echo   date:       ${{ github.event.inputs.date }}
-          echo   ol_version: ${{ github.event.inputs.ol_version }}
-          echo   driver:     openliberty-all-${{ github.event.inputs.ol_version }}-${{ github.event.inputs.build }}.zip
-          echo   guide:      ${{ github.event.inputs.guide }}
-          echo   branch:     ${{ github.event.inputs.branch }}
+          echo   build:     ${{ github.event.inputs.build }}
+          echo   date:      ${{ github.event.inputs.date }}
+          echo   driver:    ${{ github.event.inputs.driver }}
+          echo   guide:     ${{ github.event.inputs.guide }}
+          echo   branch:    ${{ github.event.inputs.branch }}
+          echo "Build level: ${{ github.event.client_payload.build-level }}${{ github.event.inputs.build }}"
   test-guide:
-    needs: [ get-guide-repos ]
+    needs: [ get-repos ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 5
       matrix:
-        repos: ${{ fromJson(needs.get-guide-repos.outputs.repos) }}
-        jdk: [ "17" ]
+        repos: ${{ fromJson(needs.get-repos.outputs.repos) }}
+        jdk: [ "21" ]
     steps:
       - name: Setup JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v1
@@ -79,45 +81,39 @@ jobs:
       - name: Run tests for ${{ matrix.repos }}
         working-directory: ${{ matrix.repos }}/finish
         env:
-          DEVDATE: ${{ github.event.inputs.date }}
-          DRIVER: openliberty-all-${{ github.event.inputs.ol_version }}-${{ github.event.inputs.build }}.zip
-          OL_VERSION: ${{ github.event.inputs.ol_version }}
-        run: sudo -E ../scripts/dockerImageTest.sh -t $DEVDATE -d $DRIVER -v $OL_VERSION
+          DEVDATE: ${{ github.event.client_payload.dev-date }}${{ github.event.inputs.date }}
+          DRIVER: ${{ github.event.client_payload.driver-location }}${{ github.event.inputs.driver }}
+        run: sudo -E ../scripts/dockerImageTest.sh -t $DEVDATE -d $DRIVER
       - name: Post tests
         working-directory: ${{ matrix.repos }}
         if: always()
         run: |
-          mvn -version
-          sudo chmod -R 777 .
           logsPath=$(sudo find . -name "console.log");
           if [ -z "$logsPath" ]
             then 
               logsPath=$(sudo find . -name "messages.log");
-              if [ -z "$logsPath" ]
-                then sudo docker images
-                else
+              if [ ! -z "$logsPath" ]
+                then
                   sudo cat $logsPath | grep product
                   sudo cat $logsPath | grep java.runtime
               fi
             else sudo cat $logsPath | grep Launching
-          fi
+          fi;
+          sudo docker images
       - name: Archive server logs if failed
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.repos }}-logs
-          path: |
-            ${{ matrix.repos }}/finish/target/liberty/wlp/usr/servers/defaultServer/logs/
-            ${{ matrix.repos }}/finish/**/target/liberty/wlp/usr/servers/defaultServer/logs/
-          if-no-files-found: ignore
+          name: server-logs
+          path: ${{ matrix.repos }}/finish/target/liberty/wlp/usr/servers/defaultServer/logs/
   slack-alert:
-    needs: [test-guide]
+    needs: [ test-guide ]
     if: failure()
     runs-on: ubuntu-latest
     env:
-      BUILDLEVEL: ${{ github.event.inputs.build }}
-      DEVDATE: ${{ github.event.inputs.date }}
-      DRIVER: openliberty-all-${{ github.event.inputs.ol_version }}-${{ github.event.inputs.build }}.zip
+      BUILDLEVEL: ${{ github.event.client_payload.build-level }}${{ github.event.inputs.build }}
+      DEVDATE: ${{ github.event.client_payload.dev-date }}${{ github.event.inputs.date }}
+      DRIVER: ${{ github.event.client_payload.driver-location }}${{ github.event.inputs.driver }}
     steps:
       - uses: actions/checkout@v2
       - name: send-status

--- a/.github/workflows/get-guides-java21.py
+++ b/.github/workflows/get-guides-java21.py
@@ -1,0 +1,6 @@
+import json
+
+JSON_PATH = ".github/workflows/guides-java21.json"
+
+if __name__ == "__main__":
+    print(json.load(open(JSON_PATH)))

--- a/.github/workflows/guides-java17.json
+++ b/.github/workflows/guides-java17.json
@@ -3,7 +3,6 @@
   "guide-jakarta-websocket",
   "guide-jms-intro",
   "guide-liberty-deep-dive",
-  "guide-liberty-deep-dive-gradle",
-  "guide-spring-boot"
+  "guide-liberty-deep-dive-gradle"
 ]
 

--- a/.github/workflows/guides-java21.json
+++ b/.github/workflows/guides-java21.json
@@ -1,0 +1,4 @@
+[
+  "guide-jpa-intro",
+  "guide-spring-boot"
+]

--- a/.github/workflows/manual-gm-candidate-container-test-java21.yml
+++ b/.github/workflows/manual-gm-candidate-container-test-java21.yml
@@ -1,4 +1,4 @@
-name: Manual GM candidate container test - Java 17
+name: Manual GM candidate container test - Java 21
 
 on:
   workflow_dispatch:
@@ -35,7 +35,7 @@ jobs:
       - name: Get repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
-        run: echo "repos=[ 'guide-liberty-deep-dive' ]" >> $GITHUB_OUTPUT
+        run: echo "repos=[ 'guide-spring-boot' ]" >> $GITHUB_OUTPUT
       - name: Set repo
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.guide != 'all' }}
         id: input-guide
@@ -60,7 +60,7 @@ jobs:
       max-parallel: 5
       matrix:
         repos: ${{ fromJson(needs.get-guide-repos.outputs.repos) }}
-        jdk: [ "17" ]
+        jdk: [ "21" ]
     steps:
       - name: Setup JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v1

--- a/.github/workflows/trigger-docker-daily-test.yml
+++ b/.github/workflows/trigger-docker-daily-test.yml
@@ -50,6 +50,7 @@ jobs:
       ACCEPT_HEADER: "application/vnd.github.v3+json"
       PAYLOAD: '{ "dev-date": "${{ matrix.builds.date }}", "driver-location": "${{ matrix.builds.driver_location }}", "build-level": "${{ matrix.builds.build_level }}", "jdk": "11" }'
       PAYLOAD_JAVA17: '{ "dev-date": "${{ matrix.builds.date }}", "driver-location": "${{ matrix.builds.driver_location }}", "build-level": "${{ matrix.builds.build_level }}", "jdk": "17" }'
+      PAYLOAD_JAVA21: '{ "dev-date": "${{ matrix.builds.date }}", "driver-location": "${{ matrix.builds.driver_location }}", "build-level": "${{ matrix.builds.build_level }}", "jdk": "21" }'
     steps:
       - name: Trigger Docker image tests
         run: |
@@ -66,6 +67,10 @@ jobs:
             curl -H "Accept: $ACCEPT_HEADER" \
                  -H "Authorization: token $GH_TOKEN" \
                  -d "{ \"event_type\": \"docker-image-test-java17\", \"client_payload\": $PAYLOAD_JAVA17 }" \
+                 -X POST $URI
+            curl -H "Accept: $ACCEPT_HEADER" \
+                 -H "Authorization: token $GH_TOKEN" \
+                 -d "{ \"event_type\": \"docker-image-test-java21\", \"client_payload\": $PAYLOAD_JAVA21 }" \
                  -X POST $URI
           else
             echo Skip test because "$IMAGEBUILDLEVEL" and "${{ matrix.builds.build_level }}" do not match!


### PR DESCRIPTION
caused by issue: https://github.com/OpenLiberty/guide-spring-boot/issues/169

* Update daily-build-java21.yml

* Update guides-java17.json

* Create guides-java21.json

* Update guides-java21.json

* Update daily-build-java21.yml

* Update manual-docker-build-test-java17.yml

* Update manual-gm-candidate-container-test-java17.yml

* Create manual-gm-candidate-container-test-java21.yml

* Update manual-gm-candidate-container-test-java17.yml

* Update manual-docker-build-test-java17.yml

* Create get-guides-java21.py

* Update docker-daily-test-java17.yml

* Create docker-daily-test-java21.yml

* Update docker-daily-test-java17.yml

* Update docker-daily-test-java21.yml

* Update trigger-docker-daily-test.yml

* Update manual-gm-candidate-container-test-java17.yml

* Update manual-gm-candidate-container-test-java21.yml