### PR TITLE
Merge staging to prod - Create gitclone-no-prereqs.adoc

### DIFF
--- a/gitclone-no-prereqs.adoc
+++ b/gitclone-no-prereqs.adoc
@@ -1,0 +1,21 @@
+////
+ Copyright (c) 2025 IBM Corporation and others.
+ Licensed under Creative Commons Attribution-NoDerivatives
+ 4.0 International (CC BY-ND 4.0)
+   https://creativecommons.org/licenses/by-nd/4.0/
+ Contributors:
+     IBM Corporation
+////
+== Getting started
+
+The fastest way to work through this guide is to clone the https://github.com/openliberty/guide-{projectid}.git[Git repository^] and use the projects that are provided inside:
+
+[source#git_clone, role="command", subs="attributes"]
+----
+git clone https://github.com/openliberty/guide-{projectid}.git
+cd guide-{projectid}
+----
+
+The `start` directory contains the starting project that you will build upon.
+
+The `finish` directory contains the finished project that you will build.


### PR DESCRIPTION
For some guides that require no additional prereqs, no need to have this statement 
>Before you begin, make sure you have all the necessary prerequisites.