### PR TITLE
Migrate GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/daily-build-java17.yml
+++ b/.github/workflows/daily-build-java17.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       repos: ${{ steps.create-list.outputs.repos }}${{ steps.input-guide.outputs.repo }}
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Get default repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
@@ -66,11 +66,12 @@ jobs:
         jdk: [ "17" ]
     steps:
       - name: Setup JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
       - name: Clone ${{ matrix.repos }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: OpenLiberty/${{ matrix.repos }}
           ref: ${{ github.event.inputs.branch }}
@@ -133,7 +134,7 @@ jobs:
           fi
       - name: Archive server logs if failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.repos }}-logs
           path: |
@@ -144,7 +145,7 @@ jobs:
           if-no-files-found: ignore
       - name: Archive npm logs if failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.repos }}-npm-logs
           path: ~/.npm/_logs
@@ -158,7 +159,7 @@ jobs:
       DEVDATE: ${{ github.event.client_payload.dev-date }}${{ github.event.inputs.date }}
       DRIVER: ${{ github.event.client_payload.driver-location }}${{ github.event.inputs.driver }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: send-status
         run: |
           python3 .github/workflows/slack-alert.py ${{ env.BUILDLEVEL }} ${{ env.DRIVER }} ${{ env.DEVDATE }} ${{ needs.test-guide.result }} \

--- a/.github/workflows/daily-build-java21.yml
+++ b/.github/workflows/daily-build-java21.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       repos: ${{ steps.create-list.outputs.repos }}${{ steps.input-guide.outputs.repo }}
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Get default repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
@@ -66,11 +66,12 @@ jobs:
         jdk: [ "21" ]
     steps:
       - name: Setup JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
       - name: Clone ${{ matrix.repos }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: OpenLiberty/${{ matrix.repos }}
           ref: ${{ github.event.inputs.branch }}
@@ -124,7 +125,7 @@ jobs:
           fi
       - name: Archive server logs if failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.repos }}-logs
           path: |
@@ -135,7 +136,7 @@ jobs:
           if-no-files-found: ignore
       - name: Archive npm logs if failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.repos }}-npm-logs
           path: ~/.npm/_logs
@@ -149,7 +150,7 @@ jobs:
       DEVDATE: ${{ github.event.client_payload.dev-date }}${{ github.event.inputs.date }}
       DRIVER: ${{ github.event.client_payload.driver-location }}${{ github.event.inputs.driver }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: send-status
         run: |
           python3 .github/workflows/slack-alert.py ${{ env.BUILDLEVEL }} ${{ env.DRIVER }} ${{ env.DEVDATE }} ${{ needs.test-guide.result }} \

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -37,7 +37,7 @@ jobs:
     outputs:
       repos: ${{ steps.create-list.outputs.repos }}${{ steps.input-guide.outputs.repo }}
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Get repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
@@ -70,11 +70,12 @@ jobs:
         jdk: [ "${{ github.event.client_payload.jdk }}${{ github.event.inputs.jdk_level }}" ]
     steps:
       - name: Setup JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
       - name: Clone ${{ matrix.repos }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: OpenLiberty/${{ matrix.repos }}
           ref: ${{ github.event.inputs.branch }}
@@ -137,7 +138,7 @@ jobs:
           fi
       - name: Archive server logs if failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.repos }}-logs
           path: |
@@ -148,7 +149,7 @@ jobs:
           if-no-files-found: ignore
       - name: Archive npm logs if failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.repos }}-npm-logs
           path: ~/.npm/_logs
@@ -162,7 +163,7 @@ jobs:
       DEVDATE: ${{ github.event.client_payload.dev-date }}${{ github.event.inputs.date }}
       DRIVER: ${{ github.event.client_payload.driver-location }}${{ github.event.inputs.driver }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: send-status
         run: |
           python3 .github/workflows/slack-alert.py ${{ env.BUILDLEVEL }} ${{ env.DRIVER }} ${{ env.DEVDATE }} ${{ needs.test-guide.result }} \

--- a/.github/workflows/docker-daily-test-java17.yml
+++ b/.github/workflows/docker-daily-test-java17.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       repos: ${{ steps.create-list.outputs.repos }}${{ steps.input-guide.outputs.repo }}
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
@@ -65,11 +65,12 @@ jobs:
         jdk: [ "17" ]
     steps:
       - name: Setup JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
       - name: Clone ${{ matrix.repos }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: OpenLiberty/${{ matrix.repos }}
           ref: ${{ github.event.inputs.branch }}
@@ -111,7 +112,7 @@ jobs:
           sudo docker images
       - name: Archive server logs if failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: server-logs
           path: ${{ matrix.repos }}/finish/target/liberty/wlp/usr/servers/defaultServer/logs/
@@ -124,7 +125,7 @@ jobs:
       DEVDATE: ${{ github.event.client_payload.dev-date }}${{ github.event.inputs.date }}
       DRIVER: ${{ github.event.client_payload.driver-location }}${{ github.event.inputs.driver }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: send-status
         run: |
           python3 .github/workflows/slack-alert.py ${{ env.BUILDLEVEL }} ${{ env.DRIVER }} ${{ env.DEVDATE }} ${{ needs.test-guide.result }} \

--- a/.github/workflows/docker-daily-test-java21.yml
+++ b/.github/workflows/docker-daily-test-java21.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       repos: ${{ steps.create-list.outputs.repos }}${{ steps.input-guide.outputs.repo }}
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
@@ -65,11 +65,12 @@ jobs:
         jdk: [ "21" ]
     steps:
       - name: Setup JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
       - name: Clone ${{ matrix.repos }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: OpenLiberty/${{ matrix.repos }}
           ref: ${{ github.event.inputs.branch }}
@@ -102,7 +103,7 @@ jobs:
           sudo docker images
       - name: Archive server logs if failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: server-logs
           path: ${{ matrix.repos }}/finish/target/liberty/wlp/usr/servers/defaultServer/logs/
@@ -115,7 +116,7 @@ jobs:
       DEVDATE: ${{ github.event.client_payload.dev-date }}${{ github.event.inputs.date }}
       DRIVER: ${{ github.event.client_payload.driver-location }}${{ github.event.inputs.driver }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: send-status
         run: |
           python3 .github/workflows/slack-alert.py ${{ env.BUILDLEVEL }} ${{ env.DRIVER }} ${{ env.DEVDATE }} ${{ needs.test-guide.result }} \

--- a/.github/workflows/docker-daily-test.yml
+++ b/.github/workflows/docker-daily-test.yml
@@ -37,7 +37,7 @@ jobs:
     outputs:
       repos: ${{ steps.create-list.outputs.repos }}${{ steps.input-guide.outputs.repo }}
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get repos
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' && github.event.inputs.guide == 'all' }}
         id: create-list
@@ -70,11 +70,12 @@ jobs:
         jdk: [ "${{ github.event.client_payload.jdk }}${{ github.event.inputs.jdk_level }}" ]
     steps:
       - name: Setup JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
       - name: Clone ${{ matrix.repos }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: OpenLiberty/${{ matrix.repos }}
           ref: ${{ github.event.inputs.branch }}
@@ -116,7 +117,7 @@ jobs:
           sudo docker images
       - name: Archive server logs if failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: server-logs
           path: ${{ matrix.repos }}/finish/target/liberty/wlp/usr/servers/defaultServer/logs/
@@ -129,7 +130,7 @@ jobs:
       DEVDATE: ${{ github.event.client_payload.dev-date }}${{ github.event.inputs.date }}
       DRIVER: ${{ github.event.client_payload.driver-location }}${{ github.event.inputs.driver }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: send-status
         run: |
           python3 .github/workflows/slack-alert.py ${{ env.BUILDLEVEL }} ${{ env.DRIVER }} ${{ env.DEVDATE }} ${{ needs.test-guide.result }} \

--- a/.github/workflows/github-retry-automate.yml
+++ b/.github/workflows/github-retry-automate.yml
@@ -17,7 +17,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
     if: ${{ contains('failure,cancelled,timed_out', github.event.workflow_run.conclusion) && github.event.workflow_run.run_attempt <= 3 }}
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Info
         run: | 
           echo "Workflow Name: ${{ github.event.workflow_run.name }}"          

--- a/.github/workflows/pre-daily-build.yml
+++ b/.github/workflows/pre-daily-build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
       empty: ${{ steps.create-matrix.outputs.empty }}
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get build matrix
         id: create-matrix
         run: |

--- a/.github/workflows/trigger-docker-daily-test.yml
+++ b/.github/workflows/trigger-docker-daily-test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
       empty: ${{ steps.create-matrix.outputs.empty }}
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get build matrix
         id: create-matrix
         run: |

--- a/.github/workflows/trigger-pre-daily-build.yml
+++ b/.github/workflows/trigger-pre-daily-build.yml
@@ -25,7 +25,7 @@ jobs:
       DHE_URL: https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly
     steps:
       - name: Clone ci.docker repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: OpenLiberty/ci.docker
           path: ci.docker


### PR DESCRIPTION
## Overview
Upgraded GitHub Actions to Node.js 24 compatible versions to resolve deprecation warnings and continued workflow reliability.

## Impact
- Resolves Node.js 20 deprecation warnings across the CI/CD workflows
- Ensures compatibility with GitHub Actions runners migrating to Node.js 24

## Files Modified
- `.github/workflows/daily-build-java17.yml`
- `.github/workflows/daily-build-java21.yml`
- `.github/workflows/daily-build.yml`
- `.github/workflows/docker-daily-test-java17.yml`
- `.github/workflows/docker-daily-test-java21.yml`
- `.github/workflows/docker-daily-test.yml`
- `.github/workflows/pre-daily-build.yml`
- `.github/workflows/trigger-docker-daily-test.yml`
- `.github/workflows/trigger-pre-daily-build.yml`
- `.github/workflows/github-retry-automate.yml`

The workflows are tested and verified to run on Node.js 24 runtime.
